### PR TITLE
Prepare for release as `crate-services`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ on:
   pull_request: ~
   push:
     branches:
-      - master
+      - main
 
 jobs:
   documentation:

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .crate-docs
 .DS_Store
 .env
+.idea
 *.lint

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,10 @@
+=======
+Changes
+=======
+
+
+Unreleased
+==========
+
+- Consolidate ``cloud-reference``, ``cloud-howtos``, and ``cloud-tutorials``
+- Adjust links to accompany renaming to ``services-docs``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,3 +8,4 @@ Unreleased
 
 - Consolidate ``cloud-reference``, ``cloud-howtos``, and ``cloud-tutorials``
 - Adjust links to accompany renaming to ``services-docs``
+- Adjust intersphinx references to accompany consolidation into single repository

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==================
-CrateDB Cloud Docs
-==================
+==============================
+CrateDB Services Documentation
+==============================
 
 |ci| |rtd| |build|
 

--- a/README.rst
+++ b/README.rst
@@ -34,16 +34,16 @@ Looking for more help?
 .. _support channels: https://crate.io/support/
 
 
-.. |ci| image:: https://github.com/crate/cloud-reference/actions/workflows/docs.yml/badge.svg
+.. |ci| image:: https://github.com/crate/services-docs/actions/workflows/docs.yml/badge.svg
     :alt: CI status
     :scale: 100%
-    :target: https://github.com/crate/cloud-reference/actions/workflows/docs.yml
+    :target: https://github.com/crate/services-docs/actions/workflows/docs.yml
 
-.. |rtd| image:: https://readthedocs.org/projects/crate-cloud-reference/badge/?version=latest
+.. |rtd| image:: https://readthedocs.org/projects/crate-services/badge/?version=latest
     :alt: Read The Docs status
     :scale: 100%
-    :target: https://crate-cloud-reference.readthedocs.io/en/latest/?badge=latest
+    :target: https://crate-services.readthedocs.io/en/latest/?badge=latest
 
-.. |build| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fcloud-reference%2Fmaster%2Fdocs%2Fbuild.json
+.. |build| image:: https://img.shields.io/endpoint.svg?color=blue&url=https%3A%2F%2Fraw.githubusercontent.com%2Fcrate%2Fservices-docs%2Fmain%2Fdocs%2Fbuild.json
     :alt: Build version
-    :target: https://github.com/crate/cloud-reference/blob/master/docs/build.json
+    :target: https://github.com/crate/services-docs/blob/main/docs/build.json

--- a/docs/cloud-howtos/index.rst
+++ b/docs/cloud-howtos/index.rst
@@ -20,10 +20,10 @@ documentation for :ref:`Croud <cloud-cli:index>`, the CLI for CrateDB Cloud.
 .. NOTE::
 
     This resource assumes you know the basics. If not, check out the
-    :ref:`tutorials <cloud-tutorials:index>` section for how to get started.
-    Additionally, the :ref:`reference <cloud-reference:index>` section contains
-    a :ref:`glossary <cloud-reference:glossary>` as well as an
-    :ref:`overview <cloud-reference:overview>` of the CrateDB Cloud Console to
+    :ref:`tutorials <cloud-tutorials-index>` section for how to get started.
+    Additionally, the :ref:`reference <cloud-reference-index>` section contains
+    a :ref:`glossary <glossary>` as well as an
+    :ref:`overview <overview>` of the CrateDB Cloud Console to
     give you further information.
 
 .. SEEALSO::

--- a/docs/cloud-howtos/index.rst
+++ b/docs/cloud-howtos/index.rst
@@ -48,4 +48,4 @@ documentation for :ref:`Croud <cloud-cli:index>`, the CLI for CrateDB Cloud.
     private-endpoints
 
 
-.. _GitHub: https://github.com/crate/cloud-howtos/
+.. _GitHub: https://github.com/crate/services-docs/

--- a/docs/cloud-howtos/snapshot.rst
+++ b/docs/cloud-howtos/snapshot.rst
@@ -11,7 +11,7 @@ CrateDB handles snapshots can be found in the CrateDB documentation about
 :ref:`snapshots <crate-reference:snapshot-restore>`.
 
 You may also want to read our reference on :ref:`the backup page on the 
-CrateDB Cloud Console <cloud-reference:overview-cluster-backups>`.
+CrateDB Cloud Console <overview-cluster-backups>`.
 
 .. rubric:: Table of contents
 

--- a/docs/cloud-howtos/visualize-data-with-grafana.rst
+++ b/docs/cloud-howtos/visualize-data-with-grafana.rst
@@ -12,7 +12,7 @@ data in real-time.
 For the purposes of this guide, it is assumed that you
 have a cluster up and running and can access the Console. If not, please refer
 to the :ref:`tutorial on how to deploy a cluster for the first time
-<cloud-tutorials:cluster-deployment>`.
+<cluster-deployment>`.
 
 .. rubric:: Table of contents
 

--- a/docs/cloud-reference/billing.rst
+++ b/docs/cloud-reference/billing.rst
@@ -77,7 +77,7 @@ Invoicing
 Invoicing is handled variously depending on which deployment method you use.
 If you deploy your cluster directly via the CrateDB Cloud Console, you will be
 invoiced at the email address you provided on :ref:`signing up with CrateDB
-Cloud <cloud-tutorials:sign-up>`.
+Cloud <sign-up>`.
 
 If you use one of the marketplace offers, the invoicing is handled by the
 marketplace provider in question and will be part of your general invoicing for
@@ -114,7 +114,7 @@ Payment processing
 ==================
 
 For clusters deployed in the :ref:`regular way
-<cloud-tutorials:cluster-deployment-stripe>`, using our CrateDB Console cluster
+<cluster-deployment-stripe>`, using our CrateDB Console cluster
 deployment route, payment processing is handled by `Stripe`_. For clusters
 deployed through the `Microsoft Azure Marketplace`_ and the `AWS Marketplace`_,
 payment is handled by Stripe on behalf of the respective marketplaces.

--- a/docs/cloud-reference/subscription-plans.rst
+++ b/docs/cloud-reference/subscription-plans.rst
@@ -65,7 +65,7 @@ This plan is aimed at new users who want to test and evaluate CrateDB Cloud
 and is perpetually free to use. Every user can deploy one free tier cluster 
 in their organization without adding a payment method. This plan
 also doesn't consume any 
-:ref:`Free Credit <cloud-tutorials:free-trial-budget>` that you may have
+:ref:`Free Credit <free-trial-budget>` that you may have
 available. They are limited to one node with 2 CPUs, 2 GiB of memory, and 4
 GiB of storage.
 
@@ -122,9 +122,8 @@ scaling up/down:
 - Usage is billed based on consumption
 - Billing is done in $0.001 increments for the compute + storage usage
 
-For details visit :ref:`Azure
-<cloud-tutorials:signup-azure-to-cluster>`, or :ref:`AWS
-<cloud-tutorials:signup-aws-to-cluster>` marketplace deployment tutorials.
+For details visit :ref:`Azure <signup-azure-to-cluster>`, or :ref:`AWS
+<signup-aws-to-cluster>` marketplace deployment tutorials.
 
 .. _subscription-plans-contracts:
 

--- a/docs/cloud-reference/user-roles.rst
+++ b/docs/cloud-reference/user-roles.rst
@@ -95,8 +95,8 @@ Regular database user
 
 Next to the ``crate`` user there is the regular database user, created as part
 of the CrateDB Cloud cluster deployment wizard when deploying a cluster 
-through :ref:`AWS <cloud-tutorials:signup-aws-to-cluster>` or
-:ref:`Azure <cloud-tutorials:signup-azure-to-cluster>`.
+through :ref:`AWS <signup-aws-to-cluster>` or
+:ref:`Azure <signup-azure-to-cluster>`.
 
 Because the regular database user has `AL privileges`_, there are certain
 operations that they cannot perform. As of CrateDB 4.2.1, the list of such

--- a/docs/cloud-tutorials/edge/monitoring.rst
+++ b/docs/cloud-tutorials/edge/monitoring.rst
@@ -241,9 +241,9 @@ If this looks interesting to you, go to `Cloud Console`_ and give it a try!
 
 .. _and Prometheus: https://grafana.com/docs/grafana/latest/datasources/prometheus/
 .. _Cloud Console: https://console.cratedb.cloud/?utm_campaign=2022-Q3-WS-Developer-Motion&utm_source=docs
-.. _Cluster performance dashboard: https://raw.githubusercontent.com/crate/cloud-tutorials/master/docs/_extra/cratedb-edge-cluster-dashboard.json
+.. _Cluster performance dashboard: https://github.com/crate/services-docs/raw/main/docs/_extra/cratedb-edge-cluster-dashboard.json
 .. _for Loki: https://grafana.com/docs/loki/latest/
 .. _Grafana: https://grafana.com/
 .. _Loki: https://grafana.com/oss/loki/
-.. _Logs monitoring dashboard: https://raw.githubusercontent.com/crate/cloud-tutorials/master/docs/_extra/cratedb-edge-logs-dashboard.json
+.. _Logs monitoring dashboard: https://github.com/crate/services-docs/raw/main/docs/_extra/cratedb-edge-logs-dashboard.json
 .. _Prometheus: https://grafana.com/oss/prometheus/

--- a/docs/cloud-tutorials/promotions/free-trial-budget.rst
+++ b/docs/cloud-tutorials/promotions/free-trial-budget.rst
@@ -28,7 +28,7 @@ Create an organization
 
 To get the credit, simply create an organization. For the detailed
 instructions, see  :ref:`Create a new organization how-to
-<cloud-howtos:create-org>`.
+<create-org>`.
 
 Enter the desired name for the organization in the field and click *Create
 organization*. Once this is done, you will be returned to the Clusters

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-from crate.theme.rtd.conf.cloud_reference import *
+from crate.theme.rtd.conf.services import *
 
 linkcheck_ignore = [
     "https://eks1.eu-west-1.aws.cratedb.cloud",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,10 @@
+.. _services-docs-index:
+
+################
+CrateDB Services
+################
+
+
 .. _cloud-docs-index:
 
 =============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,6 +33,6 @@ in the tutorials below.
 .. _CrateDB Cloud: https://crate.io/products/cratedb-cloud/
 .. _CrateDB: https://crate.io/products/cratedb/
 .. _Croud CLI: https://crate.io/docs/cloud/cli/en/latest/
-.. _GitHub: https://github.com/crate/cloud-docs
-.. _How-To Guides: https://crate.io/docs/cloud/howtos/en/latest/
-.. _Reference: https://crate.io/docs/cloud/reference/en/latest/
+.. _GitHub: https://github.com/crate/services-docs
+.. _How-To Guides: https://crate.io/docs/services/en/latest/cloud-howtos/
+.. _Reference: https://crate.io/docs/services/en/latest/cloud-reference/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
-crate-docs-theme
+git+https://github.com/crate/crate-docs-theme@amo/adjust-leftnav
+# crate-docs-theme


### PR DESCRIPTION
## About
Make it ready to be released, by adjusting a few links, and slotting it into the documentation tree.

## References
- https://github.com/crate/crate-docs-theme/pull/391

## Dependencies
After releasing a new version of `crate-docs-theme`, 846ed03 needs to go away before this can go in.
