### PR TITLE
Fix intersphinx linkage: Cloud Docs needs a canonical `index` label

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,4 @@
+(index)=
 (cloud-docs-index)=
 
 # CrateDB Cloud


### PR DESCRIPTION
What the title says.