### PR TITLE
Disable version chooser. This project is not versioned.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,3 +13,4 @@ Unreleased
 - Refactored content about connectivity concerns to dedicated section at
   ``crate-client-tools``
 - Improve the appearance of the index/home page
+- Disable version chooser. This project is not versioned.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,12 @@
 from crate.theme.rtd.conf.cloud import *
 
+# Disable version chooser.
+html_context.update({
+    "display_version": False,
+    "current_version": None,
+    "versions": [],
+})
+
 linkcheck_ignore = [
     "https://eks1.eu-west-1.aws.cratedb.cloud",
     "https://eastus2.azure.cratedb.cloud/",


### PR DESCRIPTION
## About

Because feedback- and version chooser don't harmonize, and this project does not employ any versioning at all, disable the version chooser.

## Preview

https://crate-cloud--20.org.readthedocs.build/en/20/

## References

- https://github.com/crate/crate-docs-theme/issues/413
