### PR TITLE
Fix primary navigation expansion on redundant items

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -17,7 +17,6 @@ NoSQL with the power and simplicity of standard SQL.
 .. toctree::
     :maxdepth: 2
 
-    overview
     subscription-plans
     user-roles
     billing


### PR DESCRIPTION
## About

By removing the "overview" item from the toctree of the "Cloud Reference" page, which already got navigable by adding a dedicated item "Web Console" to the main menu, the weird rendering of the primary navigation section is mitigated.

## Problem

This screenshot outlines the problem. Thanks, @proddata.

![image](https://github.com/crate/cloud-docs/assets/453543/571ffd0b-e284-407e-9e4f-e6a56999676e)
