### PR TITLE
Fix broken link to /tutorials by re-adding a placeholder page

### DIFF
--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,15 @@
+---
+orphan: true
+---
+
+# Tutorials about CrateDB Cloud
+
+## Connecting Azure IoT Hub and CrateDB Cloud
+
+```{note}
+The previous article [Connecting Azure IoT Hub and CrateDB Cloud for the Ingestion of Sensor Data]
+redirected to this URL somehow, so we are keeping that page as a placeholder,
+and will use it to direct you to a reworked version of the same content soon.
+```
+
+[Connecting Azure IoT Hub and CrateDB Cloud for the Ingestion of Sensor Data]: https://web.archive.org/web/20220125094243/https://crate.io/blog/azure-iot-hub-cratedb-sensor-data


### PR DESCRIPTION
## About

This patch is needed, because one of the previous adjustments, to dissolve the index page of the `/tutorials` section, was responsible for breaking the link https://crate.io/blog/azure-iot-hub-cratedb-sensor-data, which apparently redirects there.

The easiest way to resolve that problem is by bringing the corresponding page back as a placeholder.

