### PR TITLE
Update default PR template (defunct)

### DIFF
--- a/.github/ISSUE_TEMPLATE/pull-request-template.md
+++ b/.github/ISSUE_TEMPLATE/pull-request-template.md
@@ -1,0 +1,19 @@
+---
+name: Pull request template
+about: This is the default template for pull requests
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## What's Inside
+
+## Preview
+
+## Highlights
+
+## Checklist
+
+ - [] Link to issue this PR refers to (if applicable):
+ - [] [CLA](https://crate.io/community/contribute/cla/) is signed


### PR DESCRIPTION
Not 100% if this is correct. I like how you edited the PR description on #55, thought we could make that the default. Is this how you do it? Following [github docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)