### PR TITLE
Create pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,5 +6,5 @@
 
 ## Checklist
 
- - [] Link to issue this PR refers to (if applicable): https://github.com/crate/tech-writing/issues/402
+ - [] Link to issue this PR refers to (if applicable):
  - [] [CLA](https://crate.io/community/contribute/cla/) is signed

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,10 @@
+## What's Inside
+
+## Preview
+
+## Highlights
+
+## Checklist
+
+ - [] Link to issue this PR refers to (if applicable): https://github.com/crate/tech-writing/issues/402
+ - [] [CLA](https://crate.io/community/contribute/cla/) is signed


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
I deleted the https://github.com/crate/cloud-docs/pull/56 as it was incorrect. Now following https://axolo.co/blog/p/part-3-github-pull-request-template it seems this is the way to edit the default pull request description.


## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud-docs/pull/56
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
