### PR TITLE
Some more link fixes

### DIFF
--- a/docs/reference/billing.md
+++ b/docs/reference/billing.md
@@ -62,8 +62,8 @@ payment methods tab, in Organization section:
 
 Invoicing is handled variously depending on which deployment method you
 use. If you deploy your cluster directly via the CrateDB Cloud Console,
-you will be invoiced at the email address you provided on
-{ref}`signing up with CrateDB Cloud. <sign-up>`
+you will be invoiced at the email address you provided when
+{ref}`signing up with CrateDB Cloud. <quick-start>`
 
 If you use one of the marketplace offers, the invoicing is handled by
 the marketplace provider in question and will be part of your general

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -97,8 +97,7 @@ or Microsoft Azure account or by creating a separate username and
 password.
 
 If you don't have a Cloud Console account yet, follow the steps in the
-[signup
-tutorial](https://crate.io/docs/cloud/tutorials/en/latest/sign-up.html).
+{ref}`signup tutorial <quick-start>`.
 Select the authentication method you wish to use. From there, you will
 be given the option to sign up.
 

--- a/docs/tutorials/deploy/croud.md
+++ b/docs/tutorials/deploy/croud.md
@@ -3,7 +3,7 @@
 
 This tutorial will outline a step-by-step guide to deploying a cluster
 using the Cloud CLI application from scratch. The walkthrough assumes
-you have completed the {ref}`signup process <sign-up>` successfully, 
+you have completed the {ref}`signup process <quick-start>` successfully, 
 and that the `croud` program {ref}`is installed <cloud-cli:getting-started>`
 on your system.
 

--- a/docs/tutorials/deploy/index.md
+++ b/docs/tutorials/deploy/index.md
@@ -4,7 +4,7 @@
 # Deploy cluster
 
 This set of tutorials explains how to subscribe and deploy your cluster on
-CrateDB Cloud. The first step is always to [](#sign-up).
+CrateDB Cloud. The first step is always to {ref}`sign up <quick-start>`.
 
 After you have signed up successfully, CrateDB Cloud offers two different
 methods to subscribe and get started with deploying a cluster.

--- a/docs/tutorials/deploy/stripe.rst
+++ b/docs/tutorials/deploy/stripe.rst
@@ -6,7 +6,7 @@ Deploy cluster directly
 
 In this tutorial, we will provide a step-by-step guide to deploying a cluster
 from scratch. It is assumed you have completed the
-:ref:`signup process <sign-up>`. If you're a first-time user, a new 
+:ref:`signup process <quick-start>`. If you're a first-time user, a new 
 organization will have been created for you as a part of the signup process.
 If not, you will need to create one manually to proceed.
 

--- a/docs/tutorials/promotions/free-trial-budget.rst
+++ b/docs/tutorials/promotions/free-trial-budget.rst
@@ -14,7 +14,7 @@ user free credits worth $200. The credits can be used on any kind of
 cluster configuration.
 
 To be eligible for free credits, you will need to
-:ref:`sign up <sign-up>` for an account, and :ref:`create an organization
+:ref:`sign up <quick-start>` for an account, and :ref:`create an organization
 <create-org>`.
 
 


### PR DESCRIPTION
## What's Inside
Some more link fixes, found [here](https://github.com/crate/cloud-docs/actions/runs/8240936338/job/22537329645?pr=58#step:4:428)

## Preview

## Highlights
These are needed because of `sign-up.rst` [removal](https://github.com/crate/cloud-docs/pull/60/files#diff-8552b5c518865ffe1d9ca5d4c7b91bb53f751ebaa44904bb5420b0d6407fe096)

## Checklist

 - [ ] Link to issue this PR refers to (if applicable):
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
