### PR TITLE
Update overview.md to avoid redirect chain

### DIFF
--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -262,7 +262,7 @@ keep-alive heartbeat queries.
 
 For more information on the CrateDB concepts used here, refer to the
 [CrateDB architecture
-documentation](https://cratedb.com/docs/crate/howtos/en/latest/architecture/shared-nothing.html)
+documentation](https://cratedb.com/docs/crate/reference/en/latest/concepts/clustering.html)
 or the {ref}`glossary <glossary>`.
 
 (overview-connect-to-your-cluster)=


### PR DESCRIPTION
## What's Inside

Just a link update, currently the initial URL redirects from

https://cratedb.com/docs/crate/howtos/en/latest/architecture/shared-nothing.html
to
https://cratedb.com/docs/crate/reference/en/latest/concepts/shared-nothing.html
to
https://cratedb.com/docs/crate/reference/en/4.4/concepts/clustering.html
to
https://cratedb.com/docs/crate/reference/en/4.8/concepts/clustering.html

Which isn't even the latest version, thus this update.