### PR TITLE
Fix docutils warnings for updating to new crate-docs-theme

### DIFF
--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -59,7 +59,7 @@ Here is a list of all currently available regions for CrateDB Cloud:
 
 :::{table}
 :width: 700px
-:widths: 200, 200, 100, 100
+:widths: 300, 300
 :align: left
 | Region | Url |
 |  ----  | ----|

--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -72,7 +72,7 @@ testing, or non-critical production environments.
 **Node sizes**
 :::{table}
 :width: 700px
-:widths: 200, 200, 100, 100
+:widths: 100, 100, 150, 150, 200
 :align: left
 | Plan | Size   | vCPUs     | RAM      |  Storage  |
 |----|--------|-----------|----------| ---- |
@@ -111,7 +111,7 @@ high-availability and high-throughput environments.
 **Node sizes**
 :::{table}
 :width: 700px
-:widths: 200, 200, 100, 100
+:widths: 200, 100, 100, 100, 200
 :align: left
 | Plan | Size   | vCPUs     | RAM      |  Storage  |
 |----|--------|-----------|----------| ---- |
@@ -128,7 +128,7 @@ nodes, the overall cluster size can be scaled up to the following limits:
 **Cluster sizes**
 :::{table}
 :width: 700px
-:widths: 200, 200, 100, 100
+:widths: 200, 100, 100, 150, 150
 :align: left
 | Plan | Size   | vCPUs     | RAM      |  Storage  |
 |----|--------|-----------|----------| ---- |


### PR DESCRIPTION
## About
- Make CI pass on GH-79.

## Problem
Apparently, a newer release of docutils is more strict, and bails out when reading invalid markup.
```
ERROR: "table" widths do not match the number of columns in table (5).
```

## Preview
https://crate-cloud--80.org.readthedocs.build/en/80/