### PR TITLE
Theme: Update to `crate-docs-theme>=0.37.0.dev0`, introducing dark mode

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme>=0.37.1.dev0


### PR DESCRIPTION
## About
Use the new theme that introduces dark mode. Thanks, @msbt.

## Preview
https://crate-cloud--87.org.readthedocs.build/en/87/

## References
- https://github.com/crate/crate-docs-theme/pull/546
- https://github.com/crate/crate/pull/17001