### PR TITLE
add networking page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -155,6 +155,7 @@ Backups <cluster/backups>
 Manage Cluster <cluster/manage>
 Billing <organization/billing>
 Access Management <organization/access-management>
+Networking & Connectivity <reference/networking>
 API <organization/api>
 How Tos <howtos/index>
 Croud CLI <tutorials/deploy/croud>

--- a/docs/reference/networking.md
+++ b/docs/reference/networking.md
@@ -1,0 +1,33 @@
+(networking)=
+
+# Networking & Connectivity  
+
+## CrateDB Cloud IP Addresses  
+
+This page provides the outbound IP addresses used by CrateDB Cloud across
+different regions and cloud providers. These IPs should be allowlisted if you
+use external services that require network access from CrateDB Cloud, 
+such as:  
+
+- **Import Jobs** (when pulling data from external sources)  
+- **Managed Integrations** (e.g., MongoDB CDC)  
+- **COPY FROM/TO** (e.g., AWS S3, Azure Blob Storage, Google Cloud Storage)  
+- **Snapshot Repositories** (for backups to object storage)  
+- **Foreign Data Wrappers** (when connecting to external databases via FDW)  
+
+### **Outbound IP Addresses**  
+
+:::{caution}
+CrateDB Cloud **may update outbound IPs periodically** as infrastructure evolves.   
+:::
+
+| **Cloud Provider** | **Region**         | **Outbound IP(s)**                         |
+|-------------------|------------------|-----------------------------------------|
+| **Azure**        | West Europe (aks1.westeurope)  | `51.105.153.175/32`, `108.142.34.5/32`  |
+| **Azure**        | East US 2 (aks1.eastus2)     | `52.184.241.228/32`, `52.254.31.90/32`  |
+| **AWS**          | EU West 1 (eu-west-1)       | `34.255.75.224`                         |
+| **AWS**          | US East 1 (us-east-1)       | `54.197.229.58`                         |
+| **AWS**          | US West 2 (us-west-2)       | `54.189.16.20`                          |
+| **GCP**          | US Central 1 (us-central1)  | `34.69.134.49`                          |
+
+


### PR DESCRIPTION
## What's Inside  
This PR adds a new **Networking & Connectivity** documentation page to provide users with information about **CrateDB Cloud outbound IP addresses**.

## Preview  


## Highlights  
- **New documentation page for CrateDB Cloud networking**  
- **Comprehensive list of outbound IP addresses** per **region and cloud provider**  


## Checklist  
 - [ ] Link to issue this PR refers to (if applicable): https://crate.slack.com/archives/C07SC8ZVC2K/p1738740726349789
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
