### PR TITLE
CI: Remove building docs on macOS

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,12 +11,8 @@ concurrency:
 
 jobs:
   documentation:
-    name: Build docs on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    name: Build docs on ubuntu-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
For same reasons as https://github.com/crate/cratedb-guide/pull/201.
