### PR TITLE
Fix broken links referencing Edge.

### DIFF
--- a/docs/tutorials/deploy/marketplace/subscribe-aws.rst
+++ b/docs/tutorials/deploy/marketplace/subscribe-aws.rst
@@ -11,9 +11,7 @@ Marketplace, your hourly usage is billed directly by Amazon, not by Crate.io.
 
 As a SaaS service, the subscription payment is arranged through AWS. The
 cluster will be hosted in the region you select as part of the configuration
-process. If you are looking for a self-hosted CrateDB Cloud service, check out
-the :ref:`CrateDB Cloud on Kubernetes tutorial <cloud-on-kubernetes>`. To pay
-directly for a  hosted cluster by credit card, see the tutorial for
+process. To pay directly for a  hosted cluster by credit card, see the tutorial for
 :ref:`direct cluster deployment <cluster-deployment-stripe>`.
 
 .. rubric:: Table of contents

--- a/docs/tutorials/deploy/marketplace/subscribe-azure.rst
+++ b/docs/tutorials/deploy/marketplace/subscribe-azure.rst
@@ -12,9 +12,7 @@ Crate.io.
 
 As a SaaS service, the subscription payment is arranged through Azure. The
 cluster will be hosted in the region you select as part of the configuration
-process. If you are looking for a self-hosted CrateDB Cloud service, check out
-the :ref:`CrateDB Cloud on Kubernetes tutorial <cloud-on-kubernetes>`. To pay
-directly for a  hosted cluster by credit card, see the tutorial for
+process. To pay directly for a  hosted cluster by credit card, see the tutorial for
 :ref:`direct cluster deployment <cluster-deployment-stripe>`.
 
 


### PR DESCRIPTION
## What's Inside
After [removing Edge docs](https://github.com/crate/cloud-docs/pull/97) there were still a few links to the Edge content.
