### PR TITLE
Remove github admonition from index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -134,12 +134,6 @@ your favorite client library to connect to a CrateDB cluster.
 ::::
 
 
-:::{note}
-Like [CrateDB itself], this is an open source documentation project. [Suggestions
-for improvements], and [source code contributions], are always welcome. {fab}`github`
-:::
-
-
 :::{toctree}
 :maxdepth: 1
 :hidden:
@@ -166,6 +160,3 @@ Reference <reference/index>
 [Croud CLI]: https://crate.io/docs/cloud/cli/
 [How-To Guides]: https://crate.io/docs/cloud/en/latest/howtos/
 [Reference]: https://crate.io/docs/cloud/en/latest/reference/
-[CrateDB itself]: https://github.com/crate/crate
-[source code contributions]: https://github.com/crate/cloud-docs/tree/main/docs
-[suggestions for improvements]: https://github.com/crate/cloud-docs/issues


### PR DESCRIPTION
## What's Inside
Remove admonition about github as we now have link top-right:

<img width="274" alt="image" src="https://github.com/user-attachments/assets/1f087fe6-ad84-4767-bcc1-6a550faa06c0" />


## Preview

### Before:
<img width="988" alt="image" src="https://github.com/user-attachments/assets/f2c64aff-ea10-4c5b-8f88-35c4fedf7c00" />

### After:
<img width="880" alt="image" src="https://github.com/user-attachments/assets/6d6d8f7a-6185-48a7-bb1e-1dbe67dba4b8" />


## Checklist

 - [x] Link to issue this PR refers to (if applicable): [#285](https://github.com/crate/tech-writing/issues/285)
