### PR TITLE
Update text about usd/eur exchange rate in Billing

### DIFF
--- a/docs/organization/billing.md
+++ b/docs/organization/billing.md
@@ -71,6 +71,12 @@ applied.
 The payment cycle is monthly and aligns with the calendar month. You will be charged
 for the previous period's usage and will receive an invoice at the email address
 you provided. If needed, you can add a new credit card to replace the current one.
+
+:::{tip}
+For customers with a billing address in the European Union, these payments are 
+processed by Stripe and invoiced in Euros at a monthly USD/EUR exchange rate, 
+which is listed in each invoice.
+:::
 ::::
 
 ::::{tab} Bank Transfer
@@ -95,11 +101,10 @@ for the previous period's usage, and an invoice will be sent to the email addres
 you provided. Payment is due within the specified terms.
 
 :::{caution}
-**Bank transfer payment is currently available only within the EU.**
+**Bank transfer payment is currently available only within the European Union.**
 
-These payments are processed by Stripe and invoiced in Euros at a fixed USD/EUR 
-exchange rate. You can find the current exchange rate within the CrateDB Cloud
-Console after setting up the bank transfer payment method.
+These payments are processed by Stripe and invoiced in Euros at a monthly 
+USD/EUR exchange rate, which is listed in each invoice.
 :::
 
 ::::


### PR DESCRIPTION
## What's Inside

After https://github.com/crate/cloud/issues/2950, the usd/eur exchange rate will be updated monthly and not be displayed in the cloud console anymore.

## Preview

Bank transfer:
<details>
<summary>Before</summary>
<img width="899" height="156" alt="image" src="https://github.com/user-attachments/assets/7390c6e4-0f85-4319-bbc2-a11d070bbd67" />
</details>
<details>
<summary>After</summary>
<img width="899" height="156" alt="image" src="https://github.com/user-attachments/assets/0c47526b-5e15-4dbf-9d6f-dbae095925c0" />
</details>

Credit card:
<details>
<summary>After</summary>
<img width="899" height="156" alt="image" src="https://github.com/user-attachments/assets/cb4b4cbf-eff2-4039-b063-cbcf047200f8" />
</details>

## Highlights

## Checklist

 - [x] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud/issues/2950
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
