### PR TITLE
StackIT is billed in EUR only

### DIFF
--- a/docs/organization/billing.md
+++ b/docs/organization/billing.md
@@ -73,8 +73,11 @@ for the previous period's usage and will receive an invoice at the email address
 you provided. If needed, you can add a new credit card to replace the current one.
 
 :::{tip}
-For customers with a billing address in the European Union, these payments are 
-processed by Stripe and invoiced in Euros at a monthly USD/EUR exchange rate, 
+Clusters running on AWS, Azure, or GCP are invoiced in USD, while clusters
+running on StackIT are invoiced in EUR.
+
+For customers with a billing address in the European Union, USD invoices are
+processed by Stripe and issued in Euros at a monthly USD/EUR exchange rate,
 which is listed in each invoice.
 :::
 ::::
@@ -103,8 +106,11 @@ you provided. Payment is due within the specified terms.
 :::{caution}
 **Bank transfer payment is currently available only within the European Union.**
 
-These payments are processed by Stripe and invoiced in Euros at a monthly 
-USD/EUR exchange rate, which is listed in each invoice.
+Clusters running on AWS, Azure, or GCP are invoiced in USD, while clusters
+running on StackIT are invoiced in EUR.
+
+USD invoices are processed by Stripe and issued in Euros at a monthly USD/EUR 
+exchange rate, which is listed in each invoice.
 :::
 
 ::::


### PR DESCRIPTION
## What's Inside

Explain that StackIT is billed in EUR only.

## Preview
Credit card subscription section:
<img width="902" height="147" alt="image" src="https://github.com/user-attachments/assets/5a4a8c7d-bf0f-4da9-8fdd-42d4c3f24ec6" />

Bank transfer subscription section:
<img width="902" height="147" alt="image" src="https://github.com/user-attachments/assets/52acfe4d-1f5d-4912-b2ea-e1e4ce80d157" />

## Highlights

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): https://github.com/crate/cloud/issues/3022
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
